### PR TITLE
changes for v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# v0.5.2
+## Changes
+- Added a new file (`region_sequences.tsv.gz`) to the debug output for `aardvark compare`. This file contains the constructed haplotype sequences for each region.
+- Replaced the region summary file in the debug output with a gzip-compressed version (`region_summary.tsv` -> `region_summary.tsv.gz`) for `aardvark compare`. In internal tests, this reduced the disk footprint by ~90% for this file.
+
+## Fixed
+- Updated `crossbeam-channel` for security update
+
+# v0.5.1
+Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "approx_eq",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT"
 description = "Aardvark - A tool for sniffing out the differences in vari-Ants"

--- a/THIRDPARTY.json
+++ b/THIRDPARTY.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "aardvark",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "authors": null,
     "repository": "https://github.com/PacificBiosciences/aardvark",
     "license": "MIT",
@@ -334,7 +334,7 @@
   },
   {
     "name": "crossbeam-channel",
-    "version": "0.5.14",
+    "version": "0.5.15",
     "authors": null,
     "repository": "https://github.com/crossbeam-rs/crossbeam",
     "license": "Apache-2.0 OR MIT",

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -111,7 +111,28 @@ The debug folder (`--debug-folder`) contains many files that may be useful for d
 The following files are currently created when this option is specified:
 
 * `cli_settings.json` - JSON dump of the exact parameters that were used to run Aardvark
-* `region_summary.tsv` - A [region-specific TSV file](#region-summary-file), containing summary statistics for each sub-problem that was created as part of the Aardvark process
+* `region_sequences.tsv.gz` - A [region-specific sequence file](#region-sequence-file) containing the Aardvark-constructed haplotype sequences for each sub-problem that was created as part of the Aardvark process. This file is gzip-compressed to reduce storage.
+* `region_summary.tsv.gz` - A [region-specific summary file](#region-summary-file), containing summary statistics for each sub-problem that was created as part of the Aardvark process. This file is gzip-compressed to reduce storage.
+
+### Region sequence file
+This file captures the constructed haplotype sequences for each region.
+
+Fields:
+* `region_id` - A unique region identifier corresponding to the `RI` field of the [debug VCFs](#debug-vcf-details)
+* `coordinates` - The coordinates of the corresponding region
+* `ref_seq` - The reference sequence within the region, which is copied from the provided reference file
+* `truth_seq1` - The first constructed truth haplotype sequence
+* `truth_seq2` - The second constructed truth haplotype sequence
+* `query_seq1` - The first constructed query haplotype sequence. In an exact match, this is expected to be identical to `truth_seq1`.
+* `query_seq2` - The second constructed query haplotype sequence. In an exact match, this is expected to be identical to `truth_seq2`.
+
+Partial example:
+```
+region_id	coordinates	ref_seq	truth_seq1	truth_seq2	query_seq1	query_seq2
+0	chr1:782956-783056	TAATTTTTTATATTGATTGTATACTGCAGTGATAATATTTTGGATGTATCAGGTTAAATAAAATTGACTGATTTCACCTTTTTCCTATTTTAAAAGTGGCT	TAATTTTTTATATTGATTGTATACTGCAGTGATAATATTTTGGATGTATCGGGTTAAATAAAATTGACTGATTTCACCTTTTTCCTATTTTAAAAGTGGCT	TAATTTTTTATATTGATTGTATACTGCAGTGATAATATTTTGGATGTATCGGGTTAAATAAAATTGACTGATTTCACCTTTTTCCTATTTTAAAAGTGGCT	TAATTTTTTATATTGATTGTATACTGCAGTGATAATATTTTGGATGTATCGGGTTAAATAAAATTGACTGATTTCACCTTTTTCCTATTTTAAAAGTGGCT	TAATTTTTTATATTGATTGTATACTGCAGTGATAATATTTTGGATGTATCGGGTTAAATAAAATTGACTGATTTCACCTTTTTCCTATTTTAAAAGTGGCT
+1	chr1:783125-783225	GTTGATGAAAAATATTGTTGGTGAGCTCTGCTTAGGTAATATATAGGACATGAGCAGAGAGGAGGCACGTGAACAGTTCTGGCCTGGAGTAGGCTTCATTG	GTTGATGAAAAATATTGTTGGTGAGCTCTGCTTAGGTAATATATAGGACACGAGCAGAGAGGAGGCACGTGAACAGTTCTGGCCTGGAGTAGGCTTCATTG	GTTGATGAAAAATATTGTTGGTGAGCTCTGCTTAGGTAATATATAGGACACGAGCAGAGAGGAGGCACGTGAACAGTTCTGGCCTGGAGTAGGCTTCATTG	GTTGATGAAAAATATTGTTGGTGAGCTCTGCTTAGGTAATATATAGGACACGAGCAGAGAGGAGGCACGTGAACAGTTCTGGCCTGGAGTAGGCTTCATTG	GTTGATGAAAAATATTGTTGGTGAGCTCTGCTTAGGTAATATATAGGACACGAGCAGAGAGGAGGCACGTGAACAGTTCTGGCCTGGAGTAGGCTTCATTG
+...
+```
 
 ### Region summary file
 This file captures summary metrics for each discrete region, similar to the overall summary statistics file.

--- a/src/data_types/compare_benchmark.rs
+++ b/src/data_types/compare_benchmark.rs
@@ -35,6 +35,9 @@ pub struct CompareBenchmark {
     /// Variant metrics for query variant
     query_variant_data: Vec<VariantMetrics>,
 
+    /// optional sequence bundle, this can use a lot of memory
+    sequence_bundle: Option<SequenceBundle>,
+
     // TODO: phasing stats, if we care to report it
 }
 
@@ -44,7 +47,9 @@ impl CompareBenchmark {
     /// * `region_id` - unique region identifier
     /// * `bm_edit_distance_h1` - edit distance between the query haplotype 1 and the best path through the truth graph
     /// * `bm_edit_distance_h2` - edit distance between the query haplotype 2 and the best path through the truth graph
-    pub fn new(region_id: u64, bm_edit_distance_h1: usize, bm_edit_distance_h2: usize) -> Self {
+    pub fn new(
+        region_id: u64, bm_edit_distance_h1: usize, bm_edit_distance_h2: usize,
+    ) -> Self {
         Self {
             region_id,
             bm_edit_distance_h1,
@@ -57,6 +62,7 @@ impl CompareBenchmark {
             variant_basepair: Default::default(),
             truth_variant_data: Default::default(),
             query_variant_data: Default::default(),
+            sequence_bundle: None,
         }
     }
 
@@ -211,6 +217,11 @@ impl CompareBenchmark {
         Ok(())
     }
 
+    /// Adds a sequence bundle to this return value
+    pub fn add_sequence_bundle(&mut self, sequence_bundle: SequenceBundle) {
+        self.sequence_bundle = Some(sequence_bundle);
+    }
+
     // wrappers that are useful for summaries
     /// Total edit distance: if 0, then it means both haplotypes exactly match *a* path in the graph.
     /// Note that this does not mean the genotypes are perfect.
@@ -253,5 +264,28 @@ impl CompareBenchmark {
 
     pub fn variant_basepair(&self) -> &BTreeMap<VariantType, SummaryMetrics> {
         &self.variant_basepair
+    }
+
+    pub fn sequence_bundle(&self) -> Option<&SequenceBundle> {
+        self.sequence_bundle.as_ref()
+    }
+}
+
+/// Wrapper that just contains a ton of sequences
+#[derive(Clone, Debug)]
+pub struct SequenceBundle {
+    pub ref_seq: String,
+    pub truth_seq1: String,
+    pub truth_seq2: String,
+    pub query_seq1: String,
+    pub query_seq2: String
+}
+
+impl SequenceBundle {
+    /// Constructor
+    pub fn new(ref_seq: String, truth_seq1: String, truth_seq2: String, query_seq1: String, query_seq2: String) -> Self {
+        Self {
+            ref_seq, truth_seq1, truth_seq2, query_seq1, query_seq2
+        }
     }
 }

--- a/src/writers/mod.rs
+++ b/src/writers/mod.rs
@@ -1,6 +1,8 @@
 
 /// Helper functions for indexing file
 pub mod noodles_idx;
+/// Generates a large sequence file; each line corresponds to a sub-region
+pub mod region_sequence;
 /// Generates the much larger region summary file; each line correspond to a sub-region
 pub mod region_summary;
 /// Generates the summary file

--- a/src/writers/region_sequence.rs
+++ b/src/writers/region_sequence.rs
@@ -1,0 +1,80 @@
+
+use flate2::write::GzEncoder;
+use serde::Serialize;
+use std::fs::File;
+use std::path::Path;
+
+use crate::data_types::compare_benchmark::CompareBenchmark;
+use crate::data_types::compare_region::CompareRegion;
+
+/// This is a wrapper for writing out summary stats to a file
+pub struct RegionSequenceWriter {
+    /// Handle on the writer
+    csv_writer: csv::Writer<GzEncoder<File>>,
+}
+
+/// Contains all the data written to each row of our stats file
+#[derive(Serialize)]
+struct RegionSequenceRow {
+    /// Unique region identifier
+    region_id: u64,
+    /// Coordinates for simple tracking
+    coordinates: String,
+    
+    ref_seq: String,
+    truth_seq1: String,
+    truth_seq2: String,
+    query_seq1: String,
+    query_seq2: String
+}
+
+impl RegionSequenceRow {
+    /// Creates a new row from labels and sequences
+    pub fn new(region: &CompareRegion, benchmark: &CompareBenchmark) -> Self {
+        let region_id = region.region_id();
+        let coordinates = format!("{}", region.coordinates());
+        let sequence_bundle = benchmark.sequence_bundle().unwrap();
+        Self {
+            region_id, coordinates,
+            ref_seq: sequence_bundle.ref_seq.clone(),
+            truth_seq1: sequence_bundle.truth_seq1.clone(),
+            truth_seq2: sequence_bundle.truth_seq2.clone(),
+            query_seq1: sequence_bundle.query_seq1.clone(),
+            query_seq2: sequence_bundle.query_seq2.clone(),
+        }
+    }
+}
+
+impl RegionSequenceWriter {
+    /// Creates a new writer to save sequences. The output will be tab-delimited and gzipped.
+    /// # Arguments
+    /// * `filename` - path to the filename that will get opened; expected to be .tsv.gz
+    pub fn new(filename: &Path) -> anyhow::Result<Self> {
+        let delimiter: u8 = b'\t';
+        let gzip_writer = GzEncoder::new(
+            File::create(filename)?,
+            // default compression = 6; the "best" mode was 2x slow with very little gains
+            flate2::Compression::default()
+        );
+
+        let csv_writer= csv::WriterBuilder::new()
+            .delimiter(delimiter)
+            .from_writer(gzip_writer);
+        Ok(Self {
+            csv_writer
+        })
+    }
+
+    /// Will write the summary out to the given file path
+    /// # Arguments
+    /// * `region` - the region of interest
+    /// * `comparison` - results for this region
+    pub fn write_region_sequences(&mut self, region: &CompareRegion, comparison: &CompareBenchmark) -> csv::Result<()> {
+        // GT level analysis
+        let row = RegionSequenceRow::new(
+            region, comparison
+        );
+        self.csv_writer.serialize(&row)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
# v0.5.2
## Changes
- Added a new file (`region_sequences.tsv.gz`) to the debug output for `aardvark compare`. This file contains the constructed haplotype sequences for each region.
- Replaced the region summary file in the debug output with a gzip-compressed version (`region_summary.tsv` -> `region_summary.tsv.gz`) for `aardvark compare`. In internal tests, this reduced the disk footprint by ~90% for this file.
