### PR TITLE
changes for v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.5.4
+## Changes
+- Added a short-circuit in the `merge` routine that checks variant lengths prior to trying a full comparison. This reduces run-time significantly when larger events are unique to an input.
+- Adds parallelization to the file loading for both `compare` and `merge`. The parallelization is across both file and chromosome for the typical process, significantly reducing initially variant loading times.
+
 # v0.5.3
 ## Changes
 - Added a new optional output file for merging (`--output-summary`) which contains statistics on the merge. See documentation for details.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 license = "MIT"
 description = "Aardvark - A tool for sniffing out the differences in vari-Ants"

--- a/THIRDPARTY.json
+++ b/THIRDPARTY.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "aardvark",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "authors": null,
     "repository": "https://github.com/PacificBiosciences/aardvark",
     "license": "MIT",

--- a/src/data_types/phase_enums.rs
+++ b/src/data_types/phase_enums.rs
@@ -98,4 +98,16 @@ impl PhasedZygosity {
             PhasedZygosity::HomozygousAlternate => (Allele::Alternate, Allele::Alternate),
         }
     }
+
+    /// Returns the number of ALT alleles for this zygosity
+    pub fn to_allele_count(&self) -> u8 {
+        match self {
+            PhasedZygosity::Unknown |
+            PhasedZygosity::HomozygousReference => 0,
+            PhasedZygosity::UnphasedHeterozygous |
+            PhasedZygosity::PhasedHet01 |
+            PhasedZygosity::PhasedHet10 => 1,
+            PhasedZygosity::HomozygousAlternate => 2,
+        }
+    }
 }


### PR DESCRIPTION
# v0.5.4
## Changes
- Added a short-circuit in the `merge` routine that checks variant lengths prior to trying a full comparison. This reduces run-time significantly when larger events are unique to an input.
- Adds parallelization to the file loading for both `compare` and `merge`. The parallelization is across both file and chromosome for the typical process, significantly reducing initially variant loading times.