### PR TITLE
sync changes for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.6.0
+## Changes
+- In `compare` mode, the `--confidence-regions` parameter has been replaced with `--regions` for consistency.
+- The progress bar has been added to the parallelized variant loading step.
+
+## Fixed
+- Fixed an issue where variants that were hemizygous would be ignored entirely. They are now treated as homozygous variants for comparison.
+
 # v0.5.4
 ## Changes
 - Added a short-circuit in the `merge` routine that checks variant lengths prior to trying a full comparison. This reduces run-time significantly when larger events are unique to an input.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "Aardvark - A tool for sniffing out the differences in vari-Ants"

--- a/THIRDPARTY.json
+++ b/THIRDPARTY.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "aardvark",
-    "version": "0.5.4",
+    "version": "0.6.0",
     "authors": null,
     "repository": "https://github.com/PacificBiosciences/aardvark",
     "license": "MIT",

--- a/src/cli/compare.rs
+++ b/src/cli/compare.rs
@@ -43,10 +43,10 @@ pub struct CompareSettings {
 
     /// Confidence regions (BED)
     #[clap(short = 'b')]
-    #[clap(long = "confidence-regions")]
+    #[clap(long = "regions")]
     #[clap(value_name = "BED")]
     #[clap(help_heading = Some("Input/Output"))]
-    pub confidence_regions: Option<PathBuf>,
+    pub regions: Option<PathBuf>,
 
     /// Output directory containing summary and VCFs
     #[clap(required = true)]
@@ -135,7 +135,7 @@ pub fn check_compare_settings(mut settings: CompareSettings) -> anyhow::Result<C
     check_required_filename(&settings.reference_fn, "Reference FASTA")?;
     check_required_filename(&settings.truth_vcf_filename, "Truth VCF")?;
     check_required_filename(&settings.query_vcf_filename, "Query VCF")?;
-    check_optional_filename(settings.confidence_regions.as_deref(), "Confidence regions")?;
+    check_optional_filename(settings.regions.as_deref(), "Regions")?;
     
     // dump stuff to the logger
     info!("\tReference: {:?}", &settings.reference_fn);
@@ -149,10 +149,10 @@ pub fn check_compare_settings(mut settings: CompareSettings) -> anyhow::Result<C
         settings.query_sample = get_vcf_sample_name(&settings.query_vcf_filename, 0)?;
     }
     info!("\tQuery sample: {:?}", &settings.query_sample);
-    if let Some(hcr_fn) = settings.confidence_regions.as_deref() {
-        info!("\tConfidence regions: {hcr_fn:?}");
+    if let Some(hcr_fn) = settings.regions.as_deref() {
+        info!("\tRegions: {hcr_fn:?}");
     } else {
-        info!("\tConfidence regions: None");
+        info!("\tRegions: None");
     }
 
     // 0 is just a sentinel for everything

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 
-use indicatif::{ParallelProgressIterator, ProgressState, ProgressStyle};
+use indicatif::ParallelProgressIterator;
 use log::{LevelFilter, debug, error, info, warn};
 use rayon::prelude::*;
 use rust_lib_reference_genome::reference_genome::ReferenceGenome;
@@ -16,6 +16,7 @@ use aardvark::data_types::summary_metrics::SummaryMetrics;
 use aardvark::merge_solver::{MergeConfigBuilder, solve_merge_region};
 use aardvark::parsing::region_generation::RegionIterator;
 use aardvark::util::json_io::save_json;
+use aardvark::util::progress_bar::get_progress_style;
 use aardvark::waffle_solver::solve_compare_region;
 use aardvark::writers::merge_summary::MergeSummaryWriter;
 use aardvark::writers::region_sequence::RegionSequenceWriter;
@@ -103,7 +104,7 @@ fn run_compare(settings: CompareSettings) {
         &settings.truth_sample,
         &settings.query_vcf_filename,
         &settings.query_sample,
-        settings.confidence_regions.as_deref(),
+        settings.regions.as_deref(),
         &reference_genome,
         settings.min_variant_gap
     ) {
@@ -516,15 +517,6 @@ fn run_merge(settings: MergeSettings) {
     }
 
     info!("Merge completed in {} seconds.", start_time.elapsed().as_secs_f64());
-}
-
-/// Shared function to pull our progress bar styling
-fn get_progress_style() -> ProgressStyle {
-    ProgressStyle::with_template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} ({percent}); ETA: {eta_precise}; Speed: {per_sec} {msg}")
-        .unwrap()
-        .with_key("percent", |state: &ProgressState, w: &mut dyn std::fmt::Write| write!(w, "{:.1}%", state.fraction()*100.0).unwrap())
-        .with_key("per_sec", |state: &ProgressState, w: &mut dyn std::fmt::Write| write!(w, "{:.0}/s", state.per_sec()).unwrap())
-        .progress_chars("##-")
 }
 
 fn main() {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,7 @@
 
 /// Helper functions for read/writing JSON via serde
 pub mod json_io;
+/// Helper functions for generating the progress bars
+pub mod progress_bar;
 /// Functions for basic sequence alignment scoring
 pub mod sequence_alignment;

--- a/src/util/progress_bar.rs
+++ b/src/util/progress_bar.rs
@@ -1,0 +1,11 @@
+
+use indicatif::{ProgressState, ProgressStyle};
+
+/// Shared function to pull our progress bar styling
+pub fn get_progress_style() -> ProgressStyle {
+    ProgressStyle::with_template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} ({percent}); ETA: {eta_precise}; Speed: {per_sec} {msg}")
+        .unwrap()
+        .with_key("percent", |state: &ProgressState, w: &mut dyn std::fmt::Write| write!(w, "{:.1}%", state.fraction()*100.0).unwrap())
+        .with_key("per_sec", |state: &ProgressState, w: &mut dyn std::fmt::Write| write!(w, "{:.0}/s", state.per_sec()).unwrap())
+        .progress_chars("##-")
+}


### PR DESCRIPTION
# v0.6.0
## Changes
- In `compare` mode, the `--confidence-regions` parameter has been replaced with `--regions` for consistency.
- The progress bar has been added to the parallelized variant loading step.