### PR TITLE
changes for v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.7.1
+## Changes
+- Added two new `GT`-specific statistics to the summary files:
+  - `truth_fn_gt` - The number of `truth_fn` where the allelic sequence was matched in both inputs, but with the wrong genotype (e.g., 1/1 in truth, 0/1 in query). This value is only populated if the `comparison` is `GT`.
+  - `query_fp_gt` - The number of `query_fp` where the allelic sequence was matched in both inputs, but with the wrong genotype (e.g., 0/1 in truth, 1/1 in query). This value is only populated if the `comparison` is `GT`.
+- Added parallelization to the writers for both `compare` and `merge`.
+
 # v0.7.0
 ## Changes
 - Added a new option to `compare` mode: `--stratifications`. If provided, this will post-annotate all regions by the provided stratifications and add additional rows to the output summary TSV, see documentation for more details.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT"
 description = "Aardvark - A tool for sniffing out the differences in vari-Ants"

--- a/THIRDPARTY.json
+++ b/THIRDPARTY.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "aardvark",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "authors": null,
     "repository": "https://github.com/PacificBiosciences/aardvark",
     "license": "MIT",

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -61,18 +61,20 @@ The summary statistics file (`summary.tsv`) is a TSV output containing high-leve
 * `metric_recall` - The recall metric, which is calculated as `truth_tp / truth_total`.
 * `metric_precision` - The precision metric, which is calculated as `query_tp / (query_tp + query_fp)`.
 * `metric_f1` - The F1 score metric, which is calculated as the harmonic mean of recall and precision. It is often used as an overall summary metric for comparisons.
+* `truth_fn_gt` - The number of `truth_fn` where the allelic sequence was matched in both inputs, but with the wrong genotype (e.g., 1/1 in truth, 0/1 in query). This value is only populated if the `comparison` is `GT`.
+* `query_fp_gt` - The number of `query_fp` where the allelic sequence was matched in both inputs, but with the wrong genotype (e.g., 0/1 in truth, 1/1 in query). This value is only populated if the `comparison` is `GT`.
 
 ### Example
 This snippet of the summary file shows the `GT` and `BASEPAIR` comparison types, filtered to `ALL`, `Snv`, and `JointIndel` variant types.
 
 ```
-compare_label	comparison	region_label	filter	variant_type	truth_total	truth_tp	truth_fn	query_total	query_tp	query_fp	metric_recall	metric_precision	metric_f1
-compare	GT	ALL	ALL	ALL	3751311	3737771	13540	3757515	3741335	16180	0.9963905951812579	0.9956939626322183	0.9960421571004356
-compare	GT	ALL	ALL	Snv	3256086	3250157	5929	3256468	3252130	4338	0.9981791021490218	0.9986678818892125	0.9984234321984007
-compare	GT	ALL	ALL	JointIndel	495225	487614	7611	501047	489205	11842	0.9846312282295926	0.9763654906625526	0.980480939116689
-compare	BASEPAIR	ALL	ALL	ALL	12661262	12624128	37134	12657970	12624128	33842	0.9970671170061879	0.997326427539329	0.9971967554150142
-compare	BASEPAIR	ALL	ALL	Snv	9087802	9075500	12302	9087548	9080279	7269	0.9986463173383399	0.9992001142662466	0.9989231390468849
-compare	BASEPAIR	ALL	ALL	JointIndel	3587078	3561871	25207	3585212	3562195	23017	0.9929728319261527	0.9935800170254925	0.9932763316834902
+compare_label	comparison	region_label	filter	variant_type	truth_total	truth_tp	truth_fn	query_total	query_tp	query_fp	metric_recall	metric_precision	metric_f1	truth_fn_gt	query_fp_gt
+compare	GT	ALL	ALL	ALL	3751311	3745038	6273	3755783	3748198	7585	0.9983277846065016	0.9979804477521731	0.9981540859628386	2062	674
+compare	GT	ALL	ALL	Snv	3256086	3254704	1382	3260867	3257726	3141	0.999575564036085	0.9990367592422505	0.9993060890111242	528	115
+compare	GT	ALL	ALL	JointIndel	495225	490334	4891	494916	490472	4444	0.9901236811550306	0.9910206984619612	0.9905719867339353	1534	559
+compare	BASEPAIR	ALL	ALL	ALL	12661284	12643818	17466	12658838	12643818	15020	0.9986205190563611	0.9988134771927724	0.9987169888043983		
+compare	BASEPAIR	ALL	ALL	Snv	9087804	9085371	2433	9097196	9091342	5854	0.9997322785570639	0.9993565050153915	0.9995443564686981		
+compare	BASEPAIR	ALL	ALL	JointIndel	3587078	3571059	16019	3577802	3568620	9182	0.9955342482098243	0.9974336198593438	0.9964830289490779
 ```
 
 ## Labeled VCF files
@@ -145,17 +147,17 @@ Fields:
 * `region_id` - A unique region identifier corresponding to the `RI` field of the [debug VCFs](#debug-vcf-details)
 * `coordinates` - The coordinates of the corresponding region
 * `comparison` - The comparison type for the metrics on the row, which will be one of `GT`, `HAP`, or `BASEPAIR`. This is a summary for `ALL` variant types.
-* `truth_total`, `truth_tp`, `truth_fn`, `query_tp`, `query_fp`, `metric_recall`, `metric_precision`, `metric_f1` - See definitions for the [summary statistics file](#summary-statistics-file)
+* `truth_total`, `truth_tp`, `truth_fn`, `query_tp`, `query_fp`, `metric_recall`, `metric_precision`, `metric_f1`, `truth_fn_gt`, `query_fp_gt` - See definitions for the [summary statistics file](#summary-statistics-file)
 
 Partial example:
 ```
-region_id	coordinates	comparison	truth_total	truth_tp	truth_fn	query_tp	query_fp	metric_recall	metric_precision	metric_f1
-0	chr1:782956-783056	GT	1	1	0	1	0	1.0	1.0	1.0
-0	chr1:782956-783056	HAP	2	2	0	2	0	1.0	1.0	1.0
-0	chr1:782956-783056	BASEPAIR	4	4	0	4	0	1.0	1.0	1.0
-1	chr1:783125-783225	GT	1	1	0	1	0	1.0	1.0	1.0
-1	chr1:783125-783225	HAP	2	2	0	2	0	1.0	1.0	1.0
-1	chr1:783125-783225	BASEPAIR	4	4	0	4	0	1.0	1.0	1.0
+region_id	coordinates	comparison	truth_total	truth_tp	truth_fn	query_total	query_tp	query_fp	metric_recall	metric_precision	metric_f1	truth_fn_gt	query_fp_gt
+0	chr1:782956-783056	GT	1	1	0	1	1	0	1.0	1.0	1.0	0	0
+0	chr1:782956-783056	HAP	2	2	0	2	2	0	1.0	1.0	1.0		
+0	chr1:782956-783056	BASEPAIR	4	4	0	4	4	0	1.0	1.0	1.0		
+1	chr1:783125-783225	GT	1	1	0	1	1	0	1.0	1.0	1.0	0	0
+1	chr1:783125-783225	HAP	2	2	0	2	2	0	1.0	1.0	1.0		
+1	chr1:783125-783225	BASEPAIR	4	4	0	4	4	0	1.0	1.0	1.0	
 ...
 ```
 

--- a/src/data_types/grouped_metrics.rs
+++ b/src/data_types/grouped_metrics.rs
@@ -2,19 +2,19 @@
 use std::collections::BTreeMap;
 use std::ops::AddAssign;
 
-use crate::data_types::summary_metrics::SummaryMetrics;
+use crate::data_types::summary_metrics::{SummaryGtMetrics, SummaryMetrics};
 use crate::data_types::variants::VariantType;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct GroupMetrics {
     /// Stores GT-level summary metrics
-    gt: SummaryMetrics,
+    gt: SummaryGtMetrics,
     /// Stores haplotype-level summary metrics; i.e., a homozygous TP counts for 2
     hap: SummaryMetrics,
     /// Stores alignment-level summary metrics (basepairs)
     basepair: SummaryMetrics,
     /// Stores the variant-level stats for GT comparison
-    variant_gt: BTreeMap<VariantType, SummaryMetrics>,
+    variant_gt: BTreeMap<VariantType, SummaryGtMetrics>,
     /// Stores the variant-level stats for hap comparison
     variant_hap: BTreeMap<VariantType, SummaryMetrics>,
     /// Stores the variant-level stats for basepair comparison
@@ -24,8 +24,8 @@ pub struct GroupMetrics {
 impl GroupMetrics {
     /// Constructor
     pub fn new(
-        gt: SummaryMetrics, hap: SummaryMetrics, basepair: SummaryMetrics,
-        variant_gt: BTreeMap<VariantType, SummaryMetrics>,
+        gt: SummaryGtMetrics, hap: SummaryMetrics, basepair: SummaryMetrics,
+        variant_gt: BTreeMap<VariantType, SummaryGtMetrics>,
         variant_hap: BTreeMap<VariantType, SummaryMetrics>,
         variant_basepair: BTreeMap<VariantType, SummaryMetrics>
     ) -> Self {
@@ -36,7 +36,7 @@ impl GroupMetrics {
     }
 
     // getters
-    pub fn gt(&self) -> &SummaryMetrics {
+    pub fn gt(&self) -> &SummaryGtMetrics {
         &self.gt
     }
 
@@ -48,7 +48,7 @@ impl GroupMetrics {
         &self.basepair
     }
 
-    pub fn variant_gt(&self) -> &BTreeMap<VariantType, SummaryMetrics> {
+    pub fn variant_gt(&self) -> &BTreeMap<VariantType, SummaryGtMetrics> {
         &self.variant_gt
     }
 
@@ -100,15 +100,15 @@ mod tests {
     #[test]
     fn test_group_add_assign() {
         let mut g1 = GroupMetrics::new(
-            SummaryMetrics::new(1, 0, 1, 0),
+            SummaryGtMetrics::new(1, 0, 1, 0, 0, 2),
             SummaryMetrics::new(1, 2, 1, 2),
             SummaryMetrics::new(3, 0, 1, 4),
-            [(VariantType::Snv, SummaryMetrics::new(1, 2, 3, 4))].into_iter().collect(),
+            [(VariantType::Snv, SummaryGtMetrics::new(1, 2, 3, 4, 0, 0))].into_iter().collect(),
             Default::default(),
             [(VariantType::Insertion, SummaryMetrics::new(1, 2, 3, 4))].into_iter().collect(),
         );
         let g2 = GroupMetrics::new(
-            SummaryMetrics::new(1, 2, 3, 4),
+            SummaryGtMetrics::new(1, 2, 3, 4, 1, 0),
             SummaryMetrics::new(4, 3, 2, 1),
             SummaryMetrics::new(0, 1, 0, 2),
             Default::default(),
@@ -117,10 +117,10 @@ mod tests {
         );
 
         let expected_sum = GroupMetrics::new(
-            SummaryMetrics::new(2, 2, 4, 4),
+            SummaryGtMetrics::new(2, 2, 4, 4, 1, 2),
             SummaryMetrics::new(5, 5, 3, 3),
             SummaryMetrics::new(3, 1, 1, 6),
-            [(VariantType::Snv, SummaryMetrics::new(1, 2, 3, 4))].into_iter().collect(),
+            [(VariantType::Snv, SummaryGtMetrics::new(1, 2, 3, 4, 0, 0))].into_iter().collect(),
             Default::default(),
             [(VariantType::Insertion, SummaryMetrics::new(3, 4, 6, 8))].into_iter().collect(),
         );

--- a/src/waffle_solver.rs
+++ b/src/waffle_solver.rs
@@ -628,7 +628,7 @@ fn generate_expected_zyg_counts(zygosities: &[PhasedZygosity]) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use crate::data_types::summary_metrics::SummaryMetrics;
+    use crate::data_types::summary_metrics::{SummaryGtMetrics, SummaryMetrics};
     use crate::data_types::variant_metrics::{VariantMetrics, VariantSource};
 
     use super::*;
@@ -744,8 +744,8 @@ mod tests {
 
         let result = solve_compare_region(&problem, &reference_genome, true, None).unwrap();
         assert_eq!(result.total_ed(), 0); // should be exact paths
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 1, query_fp: 0, truth_fn: 0, query_tp: 1});
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 1, query_fp: 0, truth_fn: 0, query_tp: 1});
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(1, 0, 1, 0, 0, 0));
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(1, 0, 1, 0));
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(2*1, 0, 2*1, 0));
         assert_eq!(result.truth_variant_data(), &[VariantMetrics::new(VariantSource::Truth, 1, 1).unwrap()]);
         assert_eq!(result.query_variant_data(), &[VariantMetrics::new(VariantSource::Query, 1, 1).unwrap()]);
@@ -788,8 +788,8 @@ mod tests {
 
         let result = solve_compare_region(&problem, &reference_genome, true, None).unwrap();
         assert_eq!(result.total_ed(), 0); // should be exact paths
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 2, query_fp: 0, truth_fn: 0, query_tp: 1}); // two variants here
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 2, query_fp: 0, truth_fn: 0, query_tp: 1});
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(2, 0, 1, 0, 0, 0)); // two variants here
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(2, 0, 1, 0));
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(2*2, 0, 2*2, 0)); // 2bp difference is shared
         assert_eq!(result.truth_variant_data(), &[
             VariantMetrics::new(VariantSource::Truth, 1, 1).unwrap(),
@@ -834,8 +834,8 @@ mod tests {
 
         let result = solve_compare_region(&problem, &reference_genome, true, None).unwrap();
         assert_eq!(result.total_ed(), 0); // should be exact paths
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 1, query_fp: 0, truth_fn: 0, query_tp: 2}); // only one variant in truth set
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 1, query_fp: 0, truth_fn: 0, query_tp: 2});
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(1, 0, 2, 0, 0, 0)); // only one variant in truth set
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(1, 0, 2, 0));
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(2*2, 0, 2*2, 0)); // 2bp difference is shared
         assert_eq!(result.truth_variant_data(), &[VariantMetrics::new(VariantSource::Truth, 1, 1).unwrap()]);
         assert_eq!(result.query_variant_data(), &[
@@ -878,8 +878,8 @@ mod tests {
 
         let result = solve_compare_region(&problem, &reference_genome, true, None).unwrap();
         assert_eq!(result.total_ed(), 0); // should be exact paths
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 1, query_fp: 0, truth_fn: 0, query_tp: 1}); // only one variant in truth set
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 2, query_fp: 0, truth_fn: 0, query_tp: 2}); // but two haplotype variants
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(1, 0, 1, 0, 0, 0)); // only one variant in truth set
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(2, 0, 2, 0)); // but two haplotype variants
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(2*2, 0, 2*2, 0)); // 1bp difference on both haps
         assert_eq!(result.truth_variant_data(), &[VariantMetrics::new(VariantSource::Truth, 2, 2).unwrap()]);
         assert_eq!(result.query_variant_data(), &[VariantMetrics::new(VariantSource::Query, 2, 2).unwrap()]);
@@ -913,8 +913,8 @@ mod tests {
 
         let result = solve_compare_region(&problem, &reference_genome, true, None).unwrap();
         assert_eq!(result.total_ed(), 1); // 1 BP ed
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 0, query_fp: 0, truth_fn: 1, query_tp: 0});
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 0, query_fp: 0, truth_fn: 1, query_tp: 0});
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(0, 1, 0, 0, 0, 0));
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(0, 1, 0, 0));
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(0, 2*1, 0, 0)); // 1bp FN
         assert_eq!(result.truth_variant_data(), &[VariantMetrics::new(VariantSource::Truth, 1, 0).unwrap()]);
         assert_eq!(result.query_variant_data(), &[]);
@@ -958,8 +958,8 @@ mod tests {
 
         let result = solve_compare_region(&problem, &reference_genome, true, None).unwrap();
         assert_eq!(result.total_ed(), 2); // two BP delta
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 2, query_fp: 1, truth_fn: 1, query_tp: 1});
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 2, query_fp: 1, truth_fn: 1, query_tp: 2});
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(2, 1, 1, 1, 0, 1));
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(2, 1, 2, 1));
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(2*2, 2*1, 2*2, 2*1)); // 2 matching bp; 1 FN, 1 FP
         assert_eq!(result.truth_variant_data(), &[
             VariantMetrics::new(VariantSource::Truth, 1, 1).unwrap(), // FP in truth space
@@ -1005,8 +1005,8 @@ mod tests {
 
         let result = solve_compare_region(&problem, &reference_genome, true, None).unwrap();
         assert_eq!(result.total_ed(), 1); // path through graph is an exact match still
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 0, query_fp: 1, truth_fn: 1, query_tp: 1});
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 1, query_fp: 1, truth_fn: 1, query_tp: 1});
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(0, 1, 1, 1, 1, 0));
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(1, 1, 1, 1));
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(3, 1, 3, 1)); // one allele is on track, the other is half-right, half-wrong
         assert_eq!(result.truth_variant_data(), &[
             VariantMetrics::new(VariantSource::Truth, 2, 1).unwrap() // expected homozygous, but found something else
@@ -1046,8 +1046,8 @@ mod tests {
 
         // our results should have two of the SNVs skipped, one in truth and one in query; this is because they can't get incorporated
         assert_eq!(result.total_ed(), 0); // add ED comes from the variant skips
-        assert_eq!(result.bm_gt(), SummaryMetrics {truth_tp: 1, query_fp: 1, truth_fn: 1, query_tp: 1}); // one right, one wrong in each
-        assert_eq!(result.bm_hap(), SummaryMetrics {truth_tp: 2, query_fp: 1, truth_fn: 1, query_tp: 2}); // two correct alleles, one skipped
+        assert_eq!(result.bm_gt(), SummaryGtMetrics::new(1, 1, 1, 1, 1, 1)); // one right, one wrong in each
+        assert_eq!(result.bm_hap(), SummaryMetrics::new(2, 1, 2, 1)); // two correct alleles, one skipped
         assert_eq!(result.bm_basepair(), SummaryMetrics::new(4, 2, 4, 2)); // same, but doubled for basepair
         assert_eq!(result.variant_basepair().get(&VariantType::Snv).unwrap(), &SummaryMetrics::new(3, 1, 3, 1)); // check that one SNV is missed, but half right in this situation
         assert_eq!(result.variant_basepair().get(&VariantType::Deletion).unwrap(), &SummaryMetrics::new(2, 0, 2, 0)); // check that one SNV is missed, but half right in this situation

--- a/src/writers/compare_parallel.rs
+++ b/src/writers/compare_parallel.rs
@@ -1,0 +1,269 @@
+
+use anyhow::Context;
+use indicatif::{MultiProgress, ProgressBar, ProgressIterator};
+use log::error;
+use std::sync::{mpsc, Arc};
+
+use crate::data_types::compare_benchmark::CompareBenchmark;
+use crate::data_types::compare_region::CompareRegion;
+use crate::util::progress_bar::get_progress_style;
+use crate::writers::region_sequence::RegionSequenceWriter;
+use crate::writers::region_summary::RegionSummaryWriter;
+use crate::writers::summary::SummaryWriter;
+use crate::writers::variant_categorizer::{index_categorizer, VariantCategorizer};
+
+/// Wrapper function that will basically generate a bunch of writer threads that each independently iterate over the results and perform file I/O.
+/// This cuts file I/O time roughly in half if we generate all outputs.
+/// If any Errors occur, unaffected files will continue to write, but this function will ultimately generate an Error also.
+/// The function also generates a multi-progress bar for monitoring everything.
+/// # Arguments
+/// * `all_results` - All of the regions and results from the core analysis
+/// * `summary_writer` - Collector of summary data, this is a reference since main will need it for printing afterwards
+/// * `vcf_writer` - Saves all the output VCFs, this function also calls the indexing of the VCFs
+/// * `region_writer` - Writes summary statistics per-region
+/// * `region_seq_writer` - Writes the haplotype sequences generated per-region, this tends to use the most time
+pub fn write_compare_outputs(
+    all_results: Vec<(CompareRegion, Option<CompareBenchmark>)>,
+    summary_writer: &mut SummaryWriter,
+    mut truth_vcf_writer: VariantCategorizer,
+    mut query_vcf_writer: VariantCategorizer,
+    mut region_writer: Option<RegionSummaryWriter>,
+    mut region_seq_writer: Option<RegionSequenceWriter>
+) -> anyhow::Result<()> {
+    // wrap the inputs in an Arc reference for reading in each thread
+    let arc_all_results = Arc::new(all_results);
+
+    // create a MultiProgress bar
+    let multi_bar = MultiProgress::new();
+
+    // create a receiver in case any of the sub-threads have Errors
+    let (arc_tx, rx) = mpsc::channel();
+    rayon::scope(|s| {
+        // This loop just gathers the summary stats into the summary writer
+        let all_results = arc_all_results.clone();
+        let pb = ProgressBar::new(all_results.len() as u64)
+            .with_style(get_progress_style())
+            .with_message("Gathering summary stats...");
+        let pb = multi_bar.add(pb);
+        pb.tick();
+        s.spawn(move|_| {
+            for (_region, opt_comparison) in all_results.iter() {
+                if let Some(comparison) = opt_comparison {
+                    // summary update
+                    summary_writer.add_comparison_benchmark(comparison);
+                } else {
+                    // one block failed, mark the error
+                    summary_writer.inc_error_blocks();
+                }
+                pb.inc(1);
+            }
+            pb.finish_with_message("Summary stats complete.");
+        });
+
+        // this loop handles truth VCF writing
+        let all_results = arc_all_results.clone();
+        let tx = arc_tx.clone();
+        let pb = ProgressBar::new(all_results.len() as u64)
+            .with_style(get_progress_style())
+            .with_message("Truth VCF writing...");
+        let pb = multi_bar.add(pb);
+        pb.tick();
+        s.spawn(move|_| {
+            let mut error = false;
+            for (region, opt_comparison) in all_results.iter() {
+                if let Some(comparison) = opt_comparison {
+                    // Write VCF results
+                    if let Err(e) = truth_vcf_writer.write_results(region, comparison)
+                        .with_context(|| "Error while writing truth VCF results:") {
+                        tx.send(e).unwrap();
+                        pb.abandon_with_message("Truth VCF writing - ERROR");
+                        error = true;
+                        break;
+                    }
+                }
+                pb.inc(1);
+            }
+
+            if !error {
+                // index the VCFs
+                pb.set_message("Truth VCF indexing...");
+                if let Err(e) = index_categorizer(truth_vcf_writer)
+                    .with_context(|| "Error while indexing truth VCF file:") {
+                    tx.send(e).unwrap();
+                    pb.abandon_with_message("Truth VCF indexing - ERROR");
+                    error = true;
+                }
+            }
+
+            if !error {
+                pb.finish_with_message("Truth VCF writing complete.");
+            }
+        });
+
+        // this loop handles query VCF writing
+        let all_results = arc_all_results.clone();
+        let tx = arc_tx.clone();
+        let pb = ProgressBar::new(all_results.len() as u64)
+            .with_style(get_progress_style())
+            .with_message("Query VCF writing...");
+        let pb = multi_bar.add(pb);
+        pb.tick();
+        s.spawn(move|_| {
+            let mut error = false;
+            for (region, opt_comparison) in all_results.iter() {
+                if let Some(comparison) = opt_comparison {
+                    // Write VCF results
+                    if let Err(e) = query_vcf_writer.write_results(region, comparison)
+                        .with_context(|| "Error while writing query VCF results:") {
+                        tx.send(e).unwrap();
+                        pb.abandon_with_message("Query VCF writing - ERROR");
+                        error = true;
+                        break;
+                    }
+                }
+                pb.inc(1);
+            }
+
+            if !error {
+                // index the VCFs
+                pb.set_message("Query VCF indexing...");
+                if let Err(e) = index_categorizer(query_vcf_writer)
+                    .with_context(|| "Error while indexing query VCF file:") {
+                    tx.send(e).unwrap();
+                    pb.abandon_with_message("Query VCF indexing - ERROR");
+                    error = true;
+                }
+            }
+
+            if !error {
+                pb.finish_with_message("Query VCF writing complete.");
+            }
+        });
+
+        // this loop handles region writing
+        if let Some(rsw) = region_writer.as_mut() {
+            let all_results = arc_all_results.clone();
+            let tx = arc_tx.clone();
+            let pb = ProgressBar::new(all_results.len() as u64)
+                .with_style(get_progress_style())
+                .with_message("Region stats writing...");
+            let pb = multi_bar.add(pb);
+            pb.tick();
+            s.spawn(move|_| {
+                let mut error = false;
+                for (region, opt_comparison) in all_results.iter() {
+                    if let Some(comparison) = opt_comparison {
+                        // Write region results
+                        if let Err(e) = rsw.write_region_summary(region, comparison)
+                            .with_context(|| "Error while writing region summary results:") {
+                            tx.send(e).unwrap();
+                            pb.abandon_with_message("Region stats writing - ERROR");
+                            error = true;
+                            break;
+                        }
+                    }
+                    pb.inc(1);
+                }
+                if !error {
+                    pb.finish_with_message("Region stats writing complete.");
+                }
+            });
+        }
+
+        // this loop handles the sequence writer
+        if let Some(rsw) = region_seq_writer.as_mut() {
+            let all_results = arc_all_results.clone();
+            let tx = arc_tx.clone();
+            let pb = ProgressBar::new(all_results.len() as u64)
+                .with_style(get_progress_style())
+                .with_message("Region sequence writing...");
+            let pb = multi_bar.add(pb);
+            pb.tick();
+            s.spawn(move|_| {
+                let mut error = false;
+                for (region, opt_comparison) in all_results.iter() {
+                    if let Some(comparison) = opt_comparison {
+                        // Write region results
+                        if let Err(e) = rsw.write_region_sequences(region, comparison)
+                            .with_context(|| "Error while writing region sequences results:") {
+                            tx.send(e).unwrap();
+                            pb.abandon_with_message("Region sequence writing - ERROR");
+                            error = true;
+                            break;
+                        }
+                    }
+                    pb.inc(1);
+                }
+                if !error {
+                    pb.finish_with_message("Region sequence writing complete.");
+                }
+            });
+        }
+    });
+
+    // drop this so rx closes
+    std::mem::drop(arc_tx);
+
+    // check if anything had an error
+    let mut result = Ok(());
+    for e in rx {
+        error!("Error while writing files: {e:#}");
+        result = Err(e);
+    }
+    result
+}
+
+/// Single threaded version of the above function. Clearly much simpler, but also slower if threads are available.
+/// This is usually ~30 seconds or so, with the above version closer to ~10.
+/// # Arguments
+/// * `all_results` - All of the regions and results from the core analysis
+/// * `summary_writer` - Collector of summary data, this is a reference since main will need it for printing afterwards
+/// * `vcf_writer` - Saves all the output VCFs, this function also calls the indexing of the VCFs
+/// * `region_writer` - Writes summary statistics per-region
+/// * `region_seq_writer` - Writes the haplotype sequences generated per-region, this tends to use the most time
+pub fn single_write_compare_outputs(
+    all_results: Vec<(CompareRegion, Option<CompareBenchmark>)>,
+    summary_writer: &mut SummaryWriter,
+    mut truth_vcf_writer: VariantCategorizer,
+    mut query_vcf_writer: VariantCategorizer,
+    mut region_writer: Option<RegionSummaryWriter>,
+    mut region_seq_writer: Option<RegionSequenceWriter>
+) -> anyhow::Result<()> {
+    for (region, opt_comparison) in all_results.into_iter()
+        .progress_with_style(get_progress_style()) {
+        if let Some(comparison) = opt_comparison {
+            // summary update
+            summary_writer.add_comparison_benchmark(&comparison);
+
+            // Write VCF results
+            truth_vcf_writer.write_results(&region, &comparison)
+                .with_context(|| "Error while writing truth VCF results:")?;
+
+            // Write VCF results
+            query_vcf_writer.write_results(&region, &comparison)
+                .with_context(|| "Error while writing query VCF results:")?;
+
+            // Write region summary results
+            if let Some(rsw) = region_writer.as_mut() {
+                rsw.write_region_summary(&region, &comparison)
+                    .with_context(|| "Error while writing region summary results:")?;
+            }
+
+            // Write region sequence results
+            if let Some(rsw) = region_seq_writer.as_mut() {
+                rsw.write_region_sequences(&region, &comparison)
+                    .with_context(|| "Error while writing region sequences results:")?;
+            }
+        } else {
+            // one block failed, mark the error
+            summary_writer.inc_error_blocks();
+        }
+    }
+
+    // finalize by indexing
+    index_categorizer(truth_vcf_writer)?;
+    index_categorizer(query_vcf_writer)?;
+
+    Ok(())
+}
+

--- a/src/writers/mod.rs
+++ b/src/writers/mod.rs
@@ -1,4 +1,6 @@
 
+/// Wrapper that handles the parallel writing of all outputs at the compare step
+pub mod compare_parallel;
 /// Generates the summary file for merging
 pub mod merge_summary;
 /// Helper functions for indexing file

--- a/src/writers/region_summary.rs
+++ b/src/writers/region_summary.rs
@@ -1,18 +1,18 @@
 
-use flate2::write::GzEncoder;
+use noodles::bgzf;
 use serde::Serialize;
 use std::fs::File;
 use std::path::Path;
 
 use crate::data_types::compare_benchmark::CompareBenchmark;
 use crate::data_types::compare_region::CompareRegion;
-use crate::data_types::summary_metrics::SummaryMetrics;
+use crate::data_types::summary_metrics::{SummaryGtMetrics, SummaryMetrics};
 use crate::writers::summary::{COMPARE_BASEPAIR, COMPARE_GT, COMPARE_HAP};
 
 /// This is a wrapper for writing out summary stats to a file
 pub struct RegionSummaryWriter {
     /// Handle on the writer
-    csv_writer: csv::Writer<GzEncoder<File>>,
+    csv_writer: csv::Writer<bgzf::MultithreadedWriter<File>>,
 }
 
 /// Contains all the data written to each row of our stats file
@@ -42,7 +42,11 @@ struct RegionSummaryRow {
     /// Precision = query.TP / (query.TP + query.FP)
     metric_precision: Option<f64>,
     /// F1 = combination score of recall and precision
-    metric_f1: Option<f64>
+    metric_f1: Option<f64>,
+    /// FN.GT = false negatives that are GT errors, so 1/1 -> 0/1; only present for GT type
+    truth_fn_gt: Option<u64>,
+    /// FP.GT = false positives that are GT errors, so 0/1 -> 1/1; only present for GT type
+    query_fp_gt: Option<u64>
 }
 
 impl RegionSummaryRow {
@@ -61,6 +65,28 @@ impl RegionSummaryRow {
             metric_recall: metrics.recall(),
             metric_precision: metrics.precision(),
             metric_f1: metrics.f1(),
+            truth_fn_gt: None,
+            query_fp_gt: None
+        }
+    }
+
+    /// Creates a new row from labels and summary metrics
+    pub fn new_gt(region: &CompareRegion, comparison: String, metrics: &SummaryGtMetrics) -> Self {
+        let region_id = region.region_id();
+        let coordinates = format!("{}", region.coordinates());
+        Self {
+            region_id, coordinates, comparison,
+            truth_total: metrics.summary_metrics.truth_tp + metrics.summary_metrics.truth_fn,
+            truth_tp: metrics.summary_metrics.truth_tp,
+            truth_fn: metrics.summary_metrics.truth_fn,
+            query_total: metrics.summary_metrics.query_tp + metrics.summary_metrics.query_fp,
+            query_tp: metrics.summary_metrics.query_tp,
+            query_fp: metrics.summary_metrics.query_fp,
+            metric_recall: metrics.summary_metrics.recall(),
+            metric_precision: metrics.summary_metrics.precision(),
+            metric_f1: metrics.summary_metrics.f1(),
+            truth_fn_gt: Some(metrics.truth_fn_gt),
+            query_fp_gt: Some(metrics.query_fp_gt)
         }
     }
 }
@@ -69,15 +95,12 @@ impl RegionSummaryWriter {
     /// Creates a new writer to accumulate stats
     /// # Arguments
     /// * `filename` - path to the filename that will get opened, must be .tsv.gz
-    pub fn new(filename: &Path) -> csv::Result<Self> {
+    /// * `threads` - worker threads for the gzip writing
+    pub fn new(filename: &Path, threads: usize) -> csv::Result<Self> {
         // modify the delimiter to "," if it ends with .csv
         let delimiter: u8 = b'\t';
-        let gzip_writer = GzEncoder::new(
-            File::create(filename)?,
-            // default compression = 6; the "best" mode was 2x slow with very little gains
-            flate2::Compression::default()
-        );
-
+        let w_threads = std::num::NonZeroUsize::new(threads.clamp(1, 4)).unwrap();
+        let gzip_writer = bgzf::MultithreadedWriter::with_worker_count(w_threads, File::create(filename)?);
         let csv_writer= csv::WriterBuilder::new()
             .delimiter(delimiter)
             .from_writer(gzip_writer);
@@ -92,7 +115,7 @@ impl RegionSummaryWriter {
     /// * `comparison` - results for this region
     pub fn write_region_summary(&mut self, region: &CompareRegion, comparison: &CompareBenchmark) -> csv::Result<()> {
         // GT level analysis
-        let gt_row = RegionSummaryRow::new(
+        let gt_row = RegionSummaryRow::new_gt(
             region, COMPARE_GT.to_string(), &comparison.bm_gt()
         );        
         self.csv_writer.serialize(&gt_row)?;
@@ -108,7 +131,6 @@ impl RegionSummaryWriter {
             region, COMPARE_BASEPAIR.to_string(), &comparison.bm_basepair()
         );        
         self.csv_writer.serialize(&gt_row)?;
-
         Ok(())
     }
 }

--- a/src/writers/variant_categorizer.rs
+++ b/src/writers/variant_categorizer.rs
@@ -1,6 +1,7 @@
 
 use anyhow::{Context, bail};
 use log::debug;
+use noodles::bgzf;
 use noodles::core::Position;
 use noodles::vcf;
 use noodles::vcf::header::record::value::{Map, map};
@@ -9,7 +10,8 @@ use noodles_util::variant::io::indexed_reader::Builder as VcfBuilder;
 use noodles::vcf::variant::record::samples::keys::key as vcf_key;
 use noodles::vcf::variant::record_buf;
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::fs::File;
+use std::path::{Path, PathBuf};
 
 use crate::data_types::compare_benchmark::CompareBenchmark;
 use crate::data_types::compare_region::CompareRegion;
@@ -24,54 +26,41 @@ pub const REGION_ID: &str = "RI";
 
 /// Wrapper struct that will parse the results from the core processes and determine where to write variants
 pub struct VariantCategorizer {
-    /// Header that goes into the truth VCFs
-    truth_header: vcf::Header,
-    /// Header that goes into the query VCFs
-    query_header: vcf::Header,
-    /// Contains links to all of the various VCF writers that we have by their source; e.g. truth
-    vcf_writers: BTreeMap<VariantSource, vcf::io::Writer<Box<dyn std::io::Write>>>
+    /// Either truth or query
+    source: VariantSource,
+    /// Track the filename
+    filename: PathBuf,
+    /// Header that goes into the VCF
+    vcf_header: vcf::Header,
+    /// The actual writer
+    vcf_writer: vcf::io::Writer<bgzf::MultithreadedWriter<File>>
 }
 
 impl VariantCategorizer {
-    /// Contructor that loads the truth and query VCFs and create the files for writing.
+    /// Contructor that loads the truth and query VCFs and create a pair of writers for the outputs.
     /// # Arguments
     /// * `truth_vcf_fn` - the input Truth VCF
     /// * `truth_sample_name` - the sample name for the truth VCFs
     /// * `query_vcf_fn` - the input Query VCF
     /// * `query_sample_name` - the sample name for the query VCFs
     /// * `debug_folder` - root of the debug folder, this will create files inside it
+    /// * `threads` - writer threads per gzip writer
     /// # Errors
     /// * if there are any problems opening the input files or writing files to the debug folder
-    pub fn new(
+    pub fn new_writer_pair(
         truth_vcf_fn: &Path,
         truth_sample_name: String,
         query_vcf_fn: &Path,
         query_sample_name: String,
-        debug_folder: &Path
-    ) -> anyhow::Result<Self> {
-        // Open the VCF files
-        let mut truth_vcf_reader = VcfBuilder::default()
-            .build_from_path(truth_vcf_fn)
-            .with_context(|| format!("Error while opening {truth_vcf_fn:?}:"))?;
-        let mut query_vcf_reader = VcfBuilder::default()
-            .build_from_path(query_vcf_fn)
-            .with_context(|| format!("Error while opening {query_vcf_fn:?}:"))?;
+        debug_folder: &Path,
+        threads: usize
+    ) -> anyhow::Result<(Self, Self)> {
+        let mut source_lookup: BTreeMap<VariantSource, Self> = Default::default();
 
-        // get the headers also
-        let mut truth_vcf_header = truth_vcf_reader.read_header()
-            .with_context(|| format!("Error while reading header of {truth_vcf_fn:?}:"))?;
-        let mut query_vcf_header = query_vcf_reader.read_header()
-            .with_context(|| format!("Error while reading header of {query_vcf_fn:?}:"))?;
-
+        // constants we add
         let ver: &str = crate::cli::core::FULL_VERSION.as_str(); // clippy gets weird about direct access
         let cli_version = format!("\"{}\"", ver);
         let cli_string = format!("\"{}\"", std::env::args().collect::<Vec<String>>().join(" "));
-        truth_vcf_header.insert("aardvark_version".parse()?, vcf::header::record::Value::from(cli_version.clone()))?;
-        truth_vcf_header.insert("aardvark_command".parse()?, vcf::header::record::Value::from(cli_string.clone()))?;
-        query_vcf_header.insert("aardvark_version".parse()?, vcf::header::record::Value::from(cli_version))?;
-        query_vcf_header.insert("aardvark_command".parse()?, vcf::header::record::Value::from(cli_string))?;
-
-        // add expected and observed allele counts to our header
         let extra_header = [
             (
                 BENCHMARK_DECISION_KEY.to_string(),
@@ -90,51 +79,68 @@ impl VariantCategorizer {
                 Map::<map::Format>::new(map::format::Number::Count(1), map::format::Type::Integer, "Region ID for the comparison")
             )
         ];
-        
-        for (header_key, header_value) in extra_header.iter() {
-            truth_vcf_header.formats_mut().insert(header_key.clone(), header_value.clone());
-            query_vcf_header.formats_mut().insert(header_key.clone(), header_value.clone());
-        }
 
-        // set the truth and query to just have a single sample
-        let truth_samples = truth_vcf_header.sample_names_mut();
-        truth_samples.clear();
-        truth_samples.insert(truth_sample_name);
-
-        let query_samples = query_vcf_header.sample_names_mut();
-        query_samples.clear();
-        query_samples.insert(query_sample_name);
-
-        // we have a lot of sub-files to write
-        let filetypes = [
-            (VariantSource::Truth, "truth.vcf.gz"),
-            (VariantSource::Query, "query.vcf.gz"),
-        ];
-
-        let mut vcf_writers: BTreeMap<VariantSource, vcf::io::Writer<Box<dyn std::io::Write>>> = Default::default();
-        for (source, filename) in filetypes.into_iter() {
-            // make the VCF and write the header
-            let vcf_fn = debug_folder.join(filename);
-            debug!("Opening {vcf_fn:?} for writing...");
-            let mut vcf_writer = vcf::io::writer::Builder::default()
-                .set_compression_method(noodles::vcf::io::CompressionMethod::Bgzf)
-                .build_from_path(vcf_fn)?;
-
-            // write the header based on the data source
-            match source {
-                VariantSource::Truth => vcf_writer.write_header(&truth_vcf_header)?,
-                VariantSource::Query => vcf_writer.write_header(&query_vcf_header)?,
+        for variant_source in [VariantSource::Truth, VariantSource::Query] {
+            let input_fn = match variant_source {
+                VariantSource::Truth => truth_vcf_fn,
+                VariantSource::Query => query_vcf_fn
+            };
+            let sample_name = match variant_source {
+                VariantSource::Truth => truth_sample_name.clone(),
+                VariantSource::Query => query_sample_name.clone()
             };
 
+            // Open the VCF file
+            let mut vcf_reader = VcfBuilder::default()
+                .build_from_path(input_fn)
+                .with_context(|| format!("Error while opening {input_fn:?}:"))?;
+
+            // get the header
+            let mut vcf_header = vcf_reader.read_header()
+                .with_context(|| format!("Error while reading header of {input_fn:?}:"))?;
+
+            // update the header
+            vcf_header.insert("aardvark_version".parse()?, vcf::header::record::Value::from(cli_version.clone()))?;
+            vcf_header.insert("aardvark_command".parse()?, vcf::header::record::Value::from(cli_string.clone()))?;
+            for (header_key, header_value) in extra_header.iter() {
+                vcf_header.formats_mut().insert(header_key.clone(), header_value.clone());
+            }
+
+            let samples = vcf_header.sample_names_mut();
+            samples.clear();
+            samples.insert(sample_name);
+
+            let out_extension = match variant_source {
+                VariantSource::Truth => "truth.vcf.gz",
+                VariantSource::Query => "query.vcf.gz"
+            };
+
+            // make the VCF and write the header
+            let vcf_fn = debug_folder.join(out_extension);
+            debug!("Opening {vcf_fn:?} for writing...");
+
+            let file = File::create(&vcf_fn)?;
+            let w_threads = std::num::NonZeroUsize::new(threads.clamp(1, 4)).unwrap();
+            let bgzf_writer = bgzf::MultithreadedWriter::with_worker_count(w_threads, file);
+            let mut vcf_writer = vcf::io::Writer::new(bgzf_writer);
+
+            // write the header based on the data source
+            vcf_writer.write_header(&vcf_header)?;
+
             // save it to our writers list
-            assert!(vcf_writers.insert(source, vcf_writer).is_none());
+            let vc = Self {
+                source: variant_source,
+                filename: vcf_fn,
+                vcf_header,
+                vcf_writer
+            };
+            assert!(source_lookup.insert(variant_source, vc).is_none());
         }
 
-        Ok(Self {
-            truth_header: truth_vcf_header,
-            query_header: query_vcf_header,
-            vcf_writers
-        })
+        // now pop and return
+        let truth_writer = source_lookup.remove(&VariantSource::Truth).unwrap();
+        let query_writer = source_lookup.remove(&VariantSource::Query).unwrap();
+        Ok((truth_writer, query_writer))
     }
 
     /// Core result writer, which currently does not check the input order at all; so user beware.
@@ -142,17 +148,22 @@ impl VariantCategorizer {
     /// * `region` - the comparison region, which contains the loaded variants
     /// * `benchmark` - the results from our comparison, which contains the classification information
     pub fn write_results(&mut self, region: &CompareRegion, benchmark: &CompareBenchmark) -> anyhow::Result<()> {
-        // sanity checks
-        if region.truth_variants().len() != benchmark.truth_variant_data().len() {
-            bail!("Region and benchmark truth lengths are different for B#{}", region.region_id());
+        match self.source {
+            VariantSource::Truth => {
+                // sanity check then write it
+                if region.truth_variants().len() != benchmark.truth_variant_data().len() {
+                    bail!("Region and benchmark truth lengths are different for B#{}", region.region_id());
+                }
+                self.write_variants(VariantSource::Truth, region.region_id(), region.coordinates().chrom(), region.truth_variants(), region.truth_zygosity(), benchmark.truth_variant_data())?;
+            },
+            VariantSource::Query => {
+                // sanity check then write it
+                if region.query_variants().len() != benchmark.query_variant_data().len() {
+                    bail!("Region and benchmark query lengths are different for B#{}", region.region_id());
+                }
+                self.write_variants(VariantSource::Query, region.region_id(), region.coordinates().chrom(), region.query_variants(), region.query_zygosity(), benchmark.query_variant_data())?;
+            },
         }
-
-        if region.query_variants().len() != benchmark.query_variant_data().len() {
-            bail!("Region and benchmark query lengths are different for B#{}", region.region_id());
-        }
-
-        self.write_variants(VariantSource::Truth, region.region_id(), region.coordinates().chrom(), region.truth_variants(), region.truth_zygosity(), benchmark.truth_variant_data())?;
-        self.write_variants(VariantSource::Query, region.region_id(), region.coordinates().chrom(), region.query_variants(), region.query_zygosity(), benchmark.query_variant_data())?;
         Ok(())
     }
 
@@ -165,10 +176,8 @@ impl VariantCategorizer {
     /// * `zygosity` - the parsed zygosity
     /// * `bench_data` - the comparison data, which determines whether the variant is a TP, FN, or FP
     fn write_variants(&mut self, source: VariantSource, region_id: u64, chrom: &str, variants: &[Variant], zygosity: &[PhasedZygosity], bench_data: &[VariantMetrics]) -> anyhow::Result<()> {
-        let vcf_header = match source {
-            VariantSource::Truth => &self.truth_header,
-            VariantSource::Query => &self.query_header,
-        };
+        // make sure we didn't do something stupid
+        assert_eq!(self.source, source);
         for ((variant, &zygosity), bd) in variants.iter().zip(zygosity.iter()).zip(bench_data.iter()) {
             // convert REF and ALT back into strings
             let ref_allele = std::str::from_utf8(variant.allele0())?;
@@ -221,36 +230,33 @@ impl VariantCategorizer {
                 .build();
 
             // save the new records to the correct VCF file
-            let vcf_writer = self.vcf_writers.get_mut(&source).unwrap();
-            vcf_writer.write_variant_record(vcf_header, &record)?;
+            self.vcf_writer.write_variant_record(&self.vcf_header, &record)?;
         }
 
         Ok(())
+    }
+
+    pub fn filename(&self) -> &Path {
+        &self.filename
     }
 }
 
 /// Helpful utility function to index all outputs from a VariantCategorizer.
 /// Critically, it consumes the writer to finalize all outputs prior to indexing.
 /// # Arguments
-/// * `debug_folder` - the output folder we are indexing
 /// * `categorizer` - the writer that gets consumed
 /// # Errors
 /// * if the noodles indexing throws any errors; this could happen if the BED file provided is not sorted
-pub fn index_categorizer(debug_folder: &Path, categorizer: VariantCategorizer) -> anyhow::Result<()> {
+pub fn index_categorizer(categorizer: VariantCategorizer) -> anyhow::Result<()> {
+    // copy all the filenames, so we can index
+    let vcf_fn = categorizer.filename().to_path_buf();
+
     // drop it from memory, this forces all the finalizing to happen
     std::mem::drop(categorizer);
 
     // now index everything
-    let extensions = [
-        "truth.vcf.gz",
-        "query.vcf.gz",
-    ];
-
-    for extension in extensions.iter() {
-        let vcf_fn = debug_folder.join(extension);
-        debug!("Generating index for {vcf_fn:?}...");
-        crate::writers::noodles_idx::index_vcf(&vcf_fn)
-            .with_context(|| format!("Error while writing index for {vcf_fn:?}"))?;
-    }
+    debug!("Generating index for {vcf_fn:?}...");
+    crate::writers::noodles_idx::index_vcf(&vcf_fn)
+        .with_context(|| format!("Error while writing index for {vcf_fn:?}"))?;
     Ok(())
 }


### PR DESCRIPTION
# v0.7.1
## Changes
- Added two new `GT`-specific statistics to the summary files:
  - `truth_fn_gt` - The number of `truth_fn` where the allelic sequence was matched in both inputs, but with the wrong genotype (e.g., 1/1 in truth, 0/1 in query). This value is only populated if the `comparison` is `GT`.
  - `query_fp_gt` - The number of `query_fp` where the allelic sequence was matched in both inputs, but with the wrong genotype (e.g., 0/1 in truth, 1/1 in query). This value is only populated if the `comparison` is `GT`.
- Added parallelization to the writers for both `compare` and `merge`.