### PR TITLE
changes for v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
+# v0.7.3
+## Changes
+- Added REF/ALT trimming of identical tail basepair sequences, which resolves some edge-case variant conflicts in the T2T truth set. This minor change tends to slightly improve the overall accuracy by reducing variant conflicts, allowing for overlapping changes when the trimming removes previously conflicting bases. Some Indel variants may be classified differently compared to previous versions. See the output VCF files for trimmed representations. Examples:
+  - AC->CC : this is trimmed to A->C and classified as a SNV now.
+  - ACC->AC : this is trimmed to AC->A and classified as a Deletion now.
+  - AC->ACC : this is trimmed to A->AC and classified as an Insertion now.
+- Adds a new option `--disable-variant-trimming` to both `compare` and `merge` modes, which disable the above trimming behavior.
+- Updated the install documentation to reflect bioconda support
+
 # v0.7.2
 ## Fixed
-* Added changes to build script to enable bioconda building from source
+- Added changes to build script to enable bioconda building from source
 
 # v0.7.1
 ## Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "MIT"
 description = "Aardvark - A tool for sniffing out the differences in vari-Ants"

--- a/THIRDPARTY.json
+++ b/THIRDPARTY.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "aardvark",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "authors": null,
     "repository": "https://github.com/PacificBiosciences/aardvark",
     "license": "MIT",

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,7 @@
 # Installing Aardvark
 ## From conda
-The easiest way to install Aardvark is through [conda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html):
+The easiest way to install Aardvark is through [conda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html).
+This will download the source code and build Aardvark locally:
 
 ```bash
 # create a brand new conda environment and install latest Aardvark
@@ -8,11 +9,11 @@ conda create -n aardvark -c bioconda aardvark
 # OR install latest into current conda environment
 conda install aardvark
 # OR install a specific version into current conda environment
-conda install aardvark=0.5.1
+conda install aardvark=0.7.2
 ```
 
-## From GitHub
-Conda updates usually lag the GitHub release by a couple days.
+## From pre-compiled binary
+We provide a pre-compiled binary file for x86_64 Linux distributions.
 Use the following instructions to get the most recent version directly from GitHub:
 
 1. Navigate to the [latest release](https://github.com/PacificBiosciences/Aardvark/releases/latest) and download the tarball file (e.g. `aardvark-{version}-x86_64-unknown-linux-gnu.tar.gz`).
@@ -21,10 +22,10 @@ Use the following instructions to get the most recent version directly from GitH
 4. Test the binary file by running it with the help option (`-h`).
 5. Visit the [User guide](./user_guide.md) for details on running Aardvark.
 
-### Example with v0.5.1
+### Example with v0.7.2
 ```bash
 # modify this to update the version
-VERSION="v0.5.1"
+VERSION="v0.7.2"
 # get the release file
 wget https://github.com/PacificBiosciences/Aardvark/releases/download/${VERSION}/aardvark-${VERSION}-x86_64-unknown-linux-gnu.tar.gz
 # decompress the file into folder ${VERSION}

--- a/src/cli/compare.rs
+++ b/src/cli/compare.rs
@@ -48,7 +48,7 @@ pub struct CompareSettings {
     #[clap(help_heading = Some("Input/Output"))]
     pub regions: Option<PathBuf>,
 
-    /// Stratifications
+    /// Stratifications, specifically the root file-of-filenames TSV
     #[clap(short = 's')]
     #[clap(long = "stratification")]
     #[clap(value_name = "TSV")]
@@ -96,6 +96,11 @@ pub struct CompareSettings {
     #[clap(help_heading = Some("Region generation"))]
     #[clap(default_value = "50")]
     pub min_variant_gap: usize,
+
+    /// Disables variant trimming, which may have a negative impact on accuracy
+    #[clap(long = "disable-variant-trimming")]
+    #[clap(help_heading = Some("Region generation"))]
+    pub disable_variant_trimming: bool,
 
     /// Maximum edit distance in the WFA comparison before quitting
     #[clap(long = "max-edit-distance")]
@@ -187,6 +192,7 @@ pub fn check_compare_settings(mut settings: CompareSettings) -> anyhow::Result<C
         bail!("--min-variant-gap must be >0");
     }
     info!("\tMinimum variant gap: {}", settings.min_variant_gap);
+    info!("\tVariant trimming: {}", if settings.disable_variant_trimming { "DISABLED "} else { "ENABLED" });
 
     // info!("Compare parameters:");
     // info!("\tMax edit distance: {}", settings.max_edit_distance); // we removed this

--- a/src/cli/merge.rs
+++ b/src/cli/merge.rs
@@ -112,6 +112,11 @@ pub struct MergeSettings {
     #[clap(default_value = "50")]
     pub min_variant_gap: usize,
 
+    /// Disables variant trimming, which may have a negative impact on accuracy
+    #[clap(long = "disable-variant-trimming")]
+    #[clap(help_heading = Some("Region generation"))]
+    pub disable_variant_trimming: bool,
+
     /// Selects pre-set merge strategy for inclusion of a variant
     #[clap(long = "merge-strategy")]
     #[clap(value_name = "STRAT")]
@@ -205,6 +210,7 @@ pub fn check_merge_settings(mut settings: MergeSettings) -> anyhow::Result<Merge
     info!("Region generation parameters:");
     ensure!(settings.min_variant_gap > 0, "--min-variant-gap must be >0");
     info!("\tMinimum variant gap: {}", settings.min_variant_gap);
+    info!("\tVariant trimming: {}", if settings.disable_variant_trimming { "DISABLED "} else { "ENABLED" });
 
     // info!("Compare parameters:");
     // info!("\tMax edit distance: {}", settings.max_edit_distance);

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,8 @@ fn run_compare(settings: CompareSettings) {
         &settings.query_sample,
         settings.regions.as_deref(),
         &reference_genome,
-        settings.min_variant_gap
+        settings.min_variant_gap,
+        !settings.disable_variant_trimming
     ) {
         Ok(ri) => ri,
         Err(e) => {
@@ -347,7 +348,8 @@ fn run_merge(settings: MergeSettings) {
         &settings.vcf_samples,
         settings.merge_regions.as_deref(),
         &reference_genome,
-        settings.min_variant_gap
+        settings.min_variant_gap,
+        !settings.disable_variant_trimming
     ) {
         Ok(ri) => ri,
         Err(e) => {


### PR DESCRIPTION
# v0.7.3
## Changes
- Added REF/ALT trimming of identical tail basepair sequences, which resolves some edge-case variant conflicts in the T2T truth set. This minor change tends to slightly improve the overall accuracy by reducing variant conflicts, allowing for overlapping changes when the trimming removes previously conflicting bases. Some Indel variants may be classified differently compared to previous versions. See the output VCF files for trimmed representations. Examples:
  - AC->CC : this is trimmed to A->C and classified as a SNV now.
  - ACC->AC : this is trimmed to AC->A and classified as a Deletion now.
  - AC->ACC : this is trimmed to A->AC and classified as an Insertion now.
- Adds a new option `--disable-variant-trimming` to both `compare` and `merge` modes, which disable the above trimming behavior.
- Updated the install documentation to reflect bioconda support