### PR TITLE
changes for v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.7.4
+## Changes
+- Adds a new scoring mode, `WEIGHTED_HAP`. This scoring mode is similar to `HAP` scoring, but variants are weighted by the number of changes between the REF and ALT sequences. For SNPs, the `HAP` and `WEIGHTED_HAP` scores should be identical since all SNPs have the same weight. For indels, each variant is effectively weighted by its length, so longer variants have an increased weight.
+
+## Fixed
+- Removed an exact-match shortcut in `compare` mode that would occasionally under-estimate the variant-level errors
+
 # v0.7.3
 ## Changes
 - Added REF/ALT trimming of identical tail basepair sequences, which resolves some edge-case variant conflicts in the T2T truth set. This minor change tends to slightly improve the overall accuracy by reducing variant conflicts, allowing for overlapping changes when the trimming removes previously conflicting bases. Some Indel variants may be classified differently compared to previous versions. See the output VCF files for trimmed representations. Examples:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 license = "MIT"
 description = "Aardvark - A tool for sniffing out the differences in vari-Ants"

--- a/THIRDPARTY.json
+++ b/THIRDPARTY.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "aardvark",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "authors": null,
     "repository": "https://github.com/PacificBiosciences/aardvark",
     "license": "MIT",

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -42,7 +42,7 @@ The summary statistics file (`summary.tsv`) is a TSV output containing high-leve
 
 ### Fields
 * `compare_label` - A user-provided comparison label that is just passed through to this output. Specified via `--compare-label` option.
-* `comparison` - The comparison type, which will be one of `GT` (genotype), `HAP` (haplotype), or `BASEPAIR` (sequence/basepair level). See [methods](./methods.md#comparison-types) for more details on each comparison type.
+* `comparison` - The comparison type, which will be one of `GT` (genotype), `HAP` (haplotype), `WEIGHTED_HAP` (weighted haplotye), or `BASEPAIR` (sequence/basepair level). See [methods](./methods.md#comparison-types) for more details on each comparison type.
 * `filter` - Indicates if any filter was applied.
 * `region_label` - The region label from stratification inputs. By default, only `ALL` is provided which contains all variants analyzed. If [stratifications](#stratifications) are provided, then additional rows for each stratification label will be added and this column will contain the label.
 * `variant_type` - The type of variant that the assessment corresponds to.

--- a/src/cli/compare.rs
+++ b/src/cli/compare.rs
@@ -110,6 +110,12 @@ pub struct CompareSettings {
     #[clap(hide = true)] // if you remove this, make sure you re-enable the CLI outputs
     pub max_edit_distance: usize,
 
+    /// Enables an exact-match compute shortcut at the cost of variant-level assessment accuracy
+    #[clap(long = "enable-exact-shortcut")]
+    #[clap(help_heading = Some("Compare parameters"))]
+    #[clap(hide = true)] // if you remove this, make sure you re-enable the CLI outputs
+    pub enable_exact_shortcut: bool,
+
     /// Number of threads to use in the benchmarking step
     #[clap(long = "threads")]
     #[clap(value_name = "THREADS")]
@@ -194,8 +200,11 @@ pub fn check_compare_settings(mut settings: CompareSettings) -> anyhow::Result<C
     info!("\tMinimum variant gap: {}", settings.min_variant_gap);
     info!("\tVariant trimming: {}", if settings.disable_variant_trimming { "DISABLED "} else { "ENABLED" });
 
-    // info!("Compare parameters:");
-    // info!("\tMax edit distance: {}", settings.max_edit_distance); // we removed this
+    if settings.enable_exact_shortcut {
+        info!("Compare parameters:");
+        // info!("\tMax edit distance: {}", settings.max_edit_distance); // we removed this
+        info!("\tExact match shortcut: {}", if settings.enable_exact_shortcut { "ENABLED" } else { "DISABLED" });
+    }
 
     if settings.threads == 0 {
         settings.threads = 1;

--- a/src/data_types/grouped_metrics.rs
+++ b/src/data_types/grouped_metrics.rs
@@ -1,9 +1,10 @@
 
+use anyhow::{bail, ensure};
 use std::collections::BTreeMap;
 use std::ops::AddAssign;
 
 use crate::data_types::summary_metrics::{SummaryGtMetrics, SummaryMetrics};
-use crate::data_types::variants::VariantType;
+use crate::data_types::variants::{Variant, VariantType};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct GroupMetrics {
@@ -11,28 +12,177 @@ pub struct GroupMetrics {
     gt: SummaryGtMetrics,
     /// Stores haplotype-level summary metrics; i.e., a homozygous TP counts for 2
     hap: SummaryMetrics,
+    /// Stores weighted haplotype-level summary metrics; weights are based on ED between REF/ALT
+    weighted_hap: SummaryMetrics,
     /// Stores alignment-level summary metrics (basepairs)
     basepair: SummaryMetrics,
     /// Stores the variant-level stats for GT comparison
     variant_gt: BTreeMap<VariantType, SummaryGtMetrics>,
     /// Stores the variant-level stats for hap comparison
     variant_hap: BTreeMap<VariantType, SummaryMetrics>,
+    /// Stores the variant-level stats for weighted hap comparison
+    variant_weighted_hap: BTreeMap<VariantType, SummaryMetrics>,
     /// Stores the variant-level stats for basepair comparison
     variant_basepair: BTreeMap<VariantType, SummaryMetrics>
 }
 
 impl GroupMetrics {
     /// Constructor
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        gt: SummaryGtMetrics, hap: SummaryMetrics, basepair: SummaryMetrics,
+        gt: SummaryGtMetrics, hap: SummaryMetrics, weighted_hap: SummaryMetrics, basepair: SummaryMetrics,
         variant_gt: BTreeMap<VariantType, SummaryGtMetrics>,
         variant_hap: BTreeMap<VariantType, SummaryMetrics>,
+        variant_weighted_hap: BTreeMap<VariantType, SummaryMetrics>,
         variant_basepair: BTreeMap<VariantType, SummaryMetrics>
     ) -> Self {
         Self {
-            gt, hap, basepair,
-            variant_gt, variant_hap, variant_basepair
+            gt, hap, weighted_hap, basepair,
+            variant_gt, variant_hap, variant_weighted_hap, variant_basepair
         }
+    }
+
+    /// Adds a truth variant comparison to the tracking
+    /// # Arguments
+    /// * `variant` - the truth variant to add
+    /// * `expected_zygosity_count` - number of times this allele was expected in the truth set; e.g. 0/1 => 1, 1/1 => 2
+    /// * `observed_zygosity_count` - number of times this allele was identified in the best-matching query haplotype sequences
+    pub fn add_truth_zygosity(&mut self, variant: &Variant, expected_zygosity_count: u8, observed_zygosity_count: u8) -> anyhow::Result<()> {
+        // we are assuming that we're only looking at non-reference genotypes
+        ensure!(expected_zygosity_count > 0, "No implementation for expecting all reference");
+
+        // get the variant type for classification, and the variant metrics for mutation
+        let variant_type = variant.variant_type();
+        let variant_weight = variant.alt_ed()? as u64;
+        let v_gt = self.variant_gt.entry(variant_type).or_default();
+        let v_hap = self.variant_hap.entry(variant_type).or_default();
+        let v_w_hap = self.variant_weighted_hap.entry(variant_type).or_default();
+
+        /*
+        In our modified exact setup, variants are either found or they are not; meaning that a false positive does not exist from a "truth" perspective.
+        Instead, a false positive is just a query variant that is not found in truth (i.e., the inverse calculations).
+        This means we should bail! if we find more observed alleles than expected.
+         */
+
+        // compare expected to observed
+        match expected_zygosity_count.cmp(&observed_zygosity_count) {
+            std::cmp::Ordering::Less => {
+                // we found too many observed relative to expected, so add the extra to FP
+                bail!("No implementation for truth false positives");
+            },
+            std::cmp::Ordering::Equal => {
+                // they match, so add one per expected
+                self.hap.truth_tp += expected_zygosity_count as u64;
+                v_hap.truth_tp += expected_zygosity_count as u64;
+
+                // weighted is same as hap but multiplied by the variant weight
+                self.weighted_hap.truth_tp += expected_zygosity_count as u64 * variant_weight;
+                v_w_hap.truth_tp += expected_zygosity_count as u64 * variant_weight;
+
+                self.gt.summary_metrics.truth_tp += 1;
+                v_gt.summary_metrics.truth_tp += 1;
+            },
+            std::cmp::Ordering::Greater => {
+                // we found too few relative to expected, so add the missing to FN
+                self.hap.truth_tp += observed_zygosity_count as u64;
+                self.hap.truth_fn += (expected_zygosity_count - observed_zygosity_count) as u64;
+                v_hap.truth_tp += observed_zygosity_count as u64;
+                v_hap.truth_fn += (expected_zygosity_count - observed_zygosity_count) as u64;
+
+                // weighted is same as hap but multiplied by the variant weight
+                self.weighted_hap.truth_tp += observed_zygosity_count as u64 * variant_weight;
+                self.weighted_hap.truth_fn += (expected_zygosity_count - observed_zygosity_count) as u64 * variant_weight;
+                v_w_hap.truth_tp += observed_zygosity_count as u64 * variant_weight;
+                v_w_hap.truth_fn += (expected_zygosity_count - observed_zygosity_count) as u64 * variant_weight;
+
+                // expected > observed, this is a false negative
+                self.gt.summary_metrics.truth_fn += 1;
+                v_gt.summary_metrics.truth_fn += 1;
+                if observed_zygosity_count > 0 {
+                    // observed was >0, this is purely a GT difference like 1/1 -> 0/1
+                    self.gt.truth_fn_gt += 1;
+                    v_gt.truth_fn_gt += 1;
+                }
+            },
+        };
+
+        Ok(())
+    }
+
+    /// Adds a query variant comparison to the tracking
+    /// # Arguments
+    /// * `variant` - the query variant to add
+    /// * `expected_zygosity_count` - number of times this allele was expected in the query set; e.g. 0/1 => 1, 1/1 => 2
+    /// * `observed_zygosity_count` - number of times this allele was identified in the best-matching truth haplotype sequences
+    pub fn add_query_zygosity(&mut self, variant: &Variant, expected_zygosity_count: u8, observed_zygosity_count: u8) -> anyhow::Result<()> {
+        // we are assuming that we're only looking at non-reference genotypes
+        ensure!(expected_zygosity_count > 0, "No implementation for expecting all reference");
+
+        // get the variant type for classification, and the variant metrics for mutation
+        let variant_type = variant.variant_type();
+        let variant_weight = variant.alt_ed()? as u64;
+        let v_gt = self.variant_gt.entry(variant_type).or_default();
+        let v_hap = self.variant_hap.entry(variant_type).or_default();
+        let v_w_hap = self.variant_weighted_hap.entry(variant_type).or_default();
+
+        // normally, we would compare expected to observed, but this function is only used for exact matches currently
+        ensure!(expected_zygosity_count == observed_zygosity_count, "No implementation for non-equal query zygosities");
+
+        // they match, so add one per expected
+        self.hap.query_tp += expected_zygosity_count as u64;
+        v_hap.query_tp += expected_zygosity_count as u64;
+
+        self.weighted_hap.query_tp += expected_zygosity_count as u64 * variant_weight;
+        v_w_hap.query_tp += expected_zygosity_count as u64 * variant_weight;
+
+        self.gt.summary_metrics.query_tp += 1;
+        v_gt.summary_metrics.query_tp += 1;
+
+        Ok(())
+    }
+
+    /// Adds basepair metrics to the current tracking
+    /// # Arguments
+    /// * `basepair_metrics` - the metrics to get added into the current values
+    /// * `variant_type` - optional variant type these stats are added to; if none, it goes into the "All" grouping
+    pub fn add_basepair_metrics(&mut self, basepair_metrics: SummaryMetrics, variant_type: Option<VariantType>) {
+        if let Some(vt) = variant_type {
+            let v_basepair = self.variant_basepair.entry(vt).or_default();
+            *v_basepair += basepair_metrics;
+        } else {
+            // all variant category
+            self.basepair += basepair_metrics;
+        }
+    }
+
+    /// Sets the values for a reverse benchmark. This is primarily to set query_tp and query_fp values from a reverse comparison.
+    /// # Arguments
+    /// * `other` - Results from a benchmark where truth and query have been swapped.
+    pub fn add_swap_benchmark(&mut self, other: &Self) -> anyhow::Result<()> {
+        // set the best match values
+        self.gt.set_query_from_truth(&other.gt);
+        self.hap.set_query_from_truth(&other.hap);
+        self.weighted_hap.set_query_from_truth(&other.weighted_hap);
+
+        // bm_basepair and variant_basepair do not compute the inverse separately
+
+        // set the per-variant values as well for both
+        for (vt, metrics) in other.variant_gt.iter() {
+            let entry = self.variant_gt.entry(*vt).or_default();
+            entry.set_query_from_truth(metrics);
+        }
+
+        for (vt, metrics) in other.variant_hap.iter() {
+            let entry = self.variant_hap.entry(*vt).or_default();
+            entry.set_query_from_truth(metrics);
+        }
+
+        for (vt, metrics) in other.variant_weighted_hap.iter() {
+            let entry = self.variant_weighted_hap.entry(*vt).or_default();
+            entry.set_query_from_truth(metrics);
+        }
+
+        Ok(())
     }
 
     // getters
@@ -42,6 +192,10 @@ impl GroupMetrics {
 
     pub fn hap(&self) -> &SummaryMetrics {
         &self.hap
+    }
+
+    pub fn weighted_hap(&self) -> &SummaryMetrics {
+        &self.weighted_hap
     }
 
     pub fn basepair(&self) -> &SummaryMetrics {
@@ -54,6 +208,10 @@ impl GroupMetrics {
 
     pub fn variant_hap(&self) -> &BTreeMap<VariantType, SummaryMetrics> {
         &self.variant_hap
+    }
+
+    pub fn variant_weighted_hap(&self) -> &BTreeMap<VariantType, SummaryMetrics> {
+        &self.variant_weighted_hap
     }
 
     pub fn variant_basepair(&self) -> &BTreeMap<VariantType, SummaryMetrics> {
@@ -73,6 +231,7 @@ impl AddAssign<&Self> for GroupMetrics {
         // overall stats
         self.gt += rhs.gt;
         self.hap += rhs.hap;
+        self.weighted_hap += rhs.weighted_hap;
         self.basepair += rhs.basepair;
 
         // variant type stats
@@ -83,6 +242,11 @@ impl AddAssign<&Self> for GroupMetrics {
 
         for (vt, metrics) in rhs.variant_hap.iter() {
             let entry = self.variant_hap.entry(*vt).or_default();
+            *entry += *metrics;
+        }
+
+        for (vt, metrics) in rhs.variant_weighted_hap.iter() {
+            let entry = self.variant_weighted_hap.entry(*vt).or_default();
             *entry += *metrics;
         }
 
@@ -102,8 +266,10 @@ mod tests {
         let mut g1 = GroupMetrics::new(
             SummaryGtMetrics::new(1, 0, 1, 0, 0, 2),
             SummaryMetrics::new(1, 2, 1, 2),
+            SummaryMetrics::new(3, 2, 1, 2),
             SummaryMetrics::new(3, 0, 1, 4),
             [(VariantType::Snv, SummaryGtMetrics::new(1, 2, 3, 4, 0, 0))].into_iter().collect(),
+            Default::default(),
             Default::default(),
             [(VariantType::Insertion, SummaryMetrics::new(1, 2, 3, 4))].into_iter().collect(),
         );
@@ -111,6 +277,8 @@ mod tests {
             SummaryGtMetrics::new(1, 2, 3, 4, 1, 0),
             SummaryMetrics::new(4, 3, 2, 1),
             SummaryMetrics::new(0, 1, 0, 2),
+            SummaryMetrics::new(0, 1, 0, 2),
+            Default::default(),
             Default::default(),
             Default::default(),
             [(VariantType::Insertion, SummaryMetrics::new(2, 2, 3, 4))].into_iter().collect(),
@@ -119,8 +287,10 @@ mod tests {
         let expected_sum = GroupMetrics::new(
             SummaryGtMetrics::new(2, 2, 4, 4, 1, 2),
             SummaryMetrics::new(5, 5, 3, 3),
+            SummaryMetrics::new(3, 3, 1, 4),
             SummaryMetrics::new(3, 1, 1, 6),
             [(VariantType::Snv, SummaryGtMetrics::new(1, 2, 3, 4, 0, 0))].into_iter().collect(),
+            Default::default(),
             Default::default(),
             [(VariantType::Insertion, SummaryMetrics::new(3, 4, 6, 8))].into_iter().collect(),
         );
@@ -128,5 +298,57 @@ mod tests {
         // now add and test
         g1 += g2;
         assert_eq!(g1, expected_sum);
+    }
+
+    // the following are some very simple tests, higher tests are in the `waffle_solver.rs` file
+
+    #[test]
+    fn test_add_truth_zygosity() {
+        let mut group_metrics = GroupMetrics::default();
+        group_metrics.add_truth_zygosity(
+            &Variant::new_insertion(0, 10, b"A".to_vec(), b"ACCC".to_vec()).unwrap(),
+            2, 2
+        ).unwrap();
+        assert_eq!(group_metrics.gt, SummaryGtMetrics::new(1, 0, 0, 0, 0, 0));
+        assert_eq!(group_metrics.hap, SummaryMetrics::new(2, 0, 0, 0));
+        assert_eq!(group_metrics.weighted_hap, SummaryMetrics::new(6, 0, 0, 0));
+        assert_eq!(group_metrics.basepair, SummaryMetrics::new(0, 0, 0, 0)); // basepair is unaffected
+    }
+
+    #[test]
+    fn test_add_query_zygosity() {
+        let mut group_metrics = GroupMetrics::default();
+        group_metrics.add_query_zygosity(
+            &Variant::new_insertion(0, 10, b"A".to_vec(), b"ACC".to_vec()).unwrap(),
+            1, 1
+        ).unwrap();
+        assert_eq!(group_metrics.gt, SummaryGtMetrics::new(0, 0, 1, 0, 0, 0));
+        assert_eq!(group_metrics.hap, SummaryMetrics::new(0, 0, 1, 0));
+        assert_eq!(group_metrics.weighted_hap, SummaryMetrics::new(0, 0, 2, 0));
+        assert_eq!(group_metrics.basepair, SummaryMetrics::new(0, 0, 0, 0)); // basepair is unaffected
+    }
+
+    #[test]
+    fn test_add_basepair_metrics() {
+        let mut group_metrics = GroupMetrics::default();
+        group_metrics.add_basepair_metrics(SummaryMetrics::new(1, 2, 3, 4), None);
+        assert_eq!(group_metrics.basepair, SummaryMetrics::new(1, 2, 3, 4));
+    }
+
+    #[test]
+    fn test_add_swap_benchmark() {
+        let mut group_metrics = GroupMetrics::default();
+        let mut other_metrics = GroupMetrics::default();
+        other_metrics.add_truth_zygosity(
+            &Variant::new_insertion(0, 10, b"A".to_vec(), b"ACC".to_vec()).unwrap(),
+            1, 1
+        ).unwrap();
+        group_metrics.add_swap_benchmark(&other_metrics).unwrap();
+
+        // one truth TP becomes one query TP
+        assert_eq!(group_metrics.gt, SummaryGtMetrics::new(0, 0, 1, 0, 0, 0));
+        assert_eq!(group_metrics.hap, SummaryMetrics::new(0, 0, 1, 0));
+        assert_eq!(group_metrics.weighted_hap, SummaryMetrics::new(0, 0, 2, 0));
+        assert_eq!(group_metrics.basepair, SummaryMetrics::new(0, 0, 0, 0)); // basepair is unaffected
     }
 }

--- a/src/data_types/summary_metrics.rs
+++ b/src/data_types/summary_metrics.rs
@@ -72,6 +72,11 @@ impl SummaryMetrics {
             None
         }
     }
+
+    /// Returns true if there are no values saved inside these metrics
+    pub fn is_empty(&self) -> bool {
+        self.truth_tp + self.truth_fn + self.query_tp + self.query_fp == 0
+    }
 }
 
 /// These are metrics that are only provided for the GT type

--- a/src/data_types/variants.rs
+++ b/src/data_types/variants.rs
@@ -1,3 +1,5 @@
+use crate::util::sequence_alignment::wfa_ed;
+
 
 /// All the variant types we are currently allowing
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -287,34 +289,6 @@ impl Variant {
         })
     }
 
-    pub fn vcf_index(&self) -> usize {
-        self.vcf_index
-    }
-
-    pub fn variant_type(&self) -> VariantType {
-        self.variant_type
-    }
-
-    pub fn position(&self) -> u64 {
-        self.position
-    }
-
-    pub fn ref_len(&self) -> usize {
-        self.allele0.len()
-    }
-
-    pub fn allele0(&self) -> &[u8] {
-        &self.allele0
-    }
-
-    pub fn allele1(&self) -> &[u8] {
-        &self.allele1
-    }
-
-    pub fn is_ignored(&self) -> bool {
-        self.is_ignored
-    }
-
     pub fn set_ignored(&mut self) {
         self.is_ignored = true;
     }
@@ -352,6 +326,40 @@ impl Variant {
         } else {
             panic!("index must be 0, 1, or 2");
         }
+    }
+
+    /// Calculates the REF/ALT edit distance for this variant
+    pub fn alt_ed(&self) -> anyhow::Result<usize> {
+        wfa_ed(&self.allele0, &self.allele1)
+    }
+
+    // getters
+    pub fn vcf_index(&self) -> usize {
+        self.vcf_index
+    }
+
+    pub fn variant_type(&self) -> VariantType {
+        self.variant_type
+    }
+
+    pub fn position(&self) -> u64 {
+        self.position
+    }
+
+    pub fn ref_len(&self) -> usize {
+        self.allele0.len()
+    }
+
+    pub fn allele0(&self) -> &[u8] {
+        &self.allele0
+    }
+
+    pub fn allele1(&self) -> &[u8] {
+        &self.allele1
+    }
+
+    pub fn is_ignored(&self) -> bool {
+        self.is_ignored
     }
 }
 

--- a/src/writers/region_summary.rs
+++ b/src/writers/region_summary.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use crate::data_types::compare_benchmark::CompareBenchmark;
 use crate::data_types::compare_region::CompareRegion;
 use crate::data_types::summary_metrics::{SummaryGtMetrics, SummaryMetrics};
-use crate::writers::summary::{COMPARE_BASEPAIR, COMPARE_GT, COMPARE_HAP};
+use crate::writers::summary::{COMPARE_BASEPAIR, COMPARE_GT, COMPARE_HAP, COMPARE_WEIGHTED_HAP};
 
 /// This is a wrapper for writing out summary stats to a file
 pub struct RegionSummaryWriter {
@@ -116,19 +116,25 @@ impl RegionSummaryWriter {
     pub fn write_region_summary(&mut self, region: &CompareRegion, comparison: &CompareBenchmark) -> csv::Result<()> {
         // GT level analysis
         let gt_row = RegionSummaryRow::new_gt(
-            region, COMPARE_GT.to_string(), &comparison.bm_gt()
+            region, COMPARE_GT.to_string(), comparison.group_metrics().gt()
         );        
         self.csv_writer.serialize(&gt_row)?;
 
         // HAP level analysis
         let gt_row = RegionSummaryRow::new(
-            region, COMPARE_HAP.to_string(), &comparison.bm_hap()
+            region, COMPARE_HAP.to_string(), comparison.group_metrics().hap()
         );        
+        self.csv_writer.serialize(&gt_row)?;
+
+        // WEIGHTED_HAP level analysis
+        let gt_row = RegionSummaryRow::new(
+            region, COMPARE_WEIGHTED_HAP.to_string(), comparison.group_metrics().weighted_hap()
+        );
         self.csv_writer.serialize(&gt_row)?;
 
         // basepair level analysis
         let gt_row = RegionSummaryRow::new(
-            region, COMPARE_BASEPAIR.to_string(), &comparison.bm_basepair()
+            region, COMPARE_BASEPAIR.to_string(), comparison.group_metrics().basepair()
         );        
         self.csv_writer.serialize(&gt_row)?;
         Ok(())


### PR DESCRIPTION
# v0.7.4
## Changes
- Adds a new scoring mode, `WEIGHTED_HAP`. This scoring mode is similar to `HAP` scoring, but variants are weighted by the number of changes between the REF and ALT sequences. For SNPs, the `HAP` and `WEIGHTED_HAP` scores should be identical since all SNPs have the same weight. For indels, each variant is effectively weighted by its length, so longer variants have an increased weight.

## Fixed
- Removed an exact-match shortcut in `compare` mode that would occasionally under-estimate the variant-level errors